### PR TITLE
Fix handling of next-version-from-metadata option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,9 +66,7 @@ export async function run() {
       nextVersionFromMetadata: argv["next-version-from-metadata"],
     });
 
-    if (argv["next-version"]) {
-      config.nextVersion = argv["next-version"];
-    }
+    config.nextVersion = config.nextVersion || argv["next-version"];
 
     let result = await new Changelog(config).createMarkdown(options);
 


### PR DESCRIPTION
The `--next-version-from-metadata` option correctly reads the repo's metadata
to define `config.nextVersion` when `loadConfig` is called. However, it is
immediately overridden on the next line by `argv["next-version"]` which
defaults to "Unreleased" and thus is always truthy.